### PR TITLE
Dev 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
     finch create --template simple
     finch create -t simple
     ```
+- Fixing commands help in Finch CLI
+
 
 ## 1.1.1
 - Updated the Finch CLI to create new projects in new paths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 ## 1.1.2
 - Adding -template option to Finch CLI to create new projects with different templates
     ```bash
-    finch create --template helloworld
-    finch create -t helloworld
+    finch create --template simple
+    finch create -t simple
     ```
 
 ## 1.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 
+## 1.1.2
+- Adding -template option to Finch CLI to create new projects with different templates
+    ```bash
+    finch create --template helloworld
+    finch create -t helloworld
+    ```
+
 ## 1.1.1
 - Updated the Finch CLI to create new projects in new paths
 - Fixed the example

--- a/bin/finch.dart
+++ b/bin/finch.dart
@@ -47,6 +47,12 @@ void main(List<String> args) async {
             shortName: 'd',
             description: 'Use docker',
           ),
+          CappOption(
+            name: 'template',
+            shortName: 't',
+            description: 'Project template (default: helloworld)',
+            value: 'helloworld',
+          ),
         ],
         run: (controller) => CreateProject().create(controller),
       ),

--- a/bin/finch.dart
+++ b/bin/finch.dart
@@ -4,6 +4,16 @@ import 'package:finch/src/cli/commands/create.dart';
 import 'package:finch/src/cli/commands/main.dart';
 
 void main(List<String> args) async {
+  final helpOption = CappOption(
+    name: 'help',
+    shortName: 'h',
+    hideInHelp: true,
+    onSelect: (CappController controller) {
+      controller.writeHelp();
+      return false;
+    },
+  );
+
   final cmdManager = CappManager(
     args: args,
     main: CappController(
@@ -32,6 +42,7 @@ void main(List<String> args) async {
         'create',
         description: 'Make new project',
         options: [
+          helpOption,
           CappOption(
             name: 'path',
             shortName: 'p',
@@ -60,20 +71,21 @@ void main(List<String> args) async {
         'get',
         description: 'Get packages of project, (dart pub get)',
         run: (controller) => ProjectCommands().get(controller),
-        options: [],
+        options: [helpOption],
       ),
       CappController(
         'runner',
         description:
             'Build runner of project, (dart pub run build_runner build)',
         run: (controller) => ProjectCommands().runner(controller),
-        options: [],
+        options: [helpOption],
       ),
       CappController(
         'run',
         description: 'Run project, (dart run)',
         run: (controller) => ProjectCommands().run(controller),
         options: [
+          helpOption,
           CappOption(
             name: 'path',
             shortName: 'p',
@@ -91,6 +103,7 @@ void main(List<String> args) async {
         description: 'Serve project with file watcher',
         run: (controller) => ProjectCommands().run(controller, serve: true),
         options: [
+          helpOption,
           CappOption(
             name: 'path',
             shortName: 'p',
@@ -108,6 +121,7 @@ void main(List<String> args) async {
         description: 'Build Project (dart compile exe)',
         run: (controller) => ProjectCommands().build(controller),
         options: [
+          helpOption,
           CappOption(
             name: 'cli',
             shortName: 'c',
@@ -148,11 +162,6 @@ void main(List<String> args) async {
             shortName: 't',
             description: 'Type of build (zip, exe)',
           ),
-          CappOption(
-            name: 'help',
-            shortName: 'h',
-            description: 'Show the help',
-          ),
         ],
       ),
       CappController(
@@ -160,6 +169,7 @@ void main(List<String> args) async {
         description: 'Unit test of project, (dart test)',
         run: (controller) => ProjectCommands().test(controller),
         options: [
+          helpOption,
           CappOption(
             name: 'reporter',
             shortName: 'r',

--- a/bin/finch.dart
+++ b/bin/finch.dart
@@ -50,8 +50,8 @@ void main(List<String> args) async {
           CappOption(
             name: 'template',
             shortName: 't',
-            description: 'Project template (default: helloworld)',
-            value: 'helloworld',
+            description: 'Project template (default: simple)',
+            value: 'simple',
           ),
         ],
         run: (controller) => CreateProject().create(controller),

--- a/bin/finch.dart
+++ b/bin/finch.dart
@@ -50,7 +50,7 @@ void main(List<String> args) async {
           CappOption(
             name: 'template',
             shortName: 't',
-            description: 'Project template (default: simple)',
+            description: 'Project template [simple, example,...]',
             value: 'simple',
           ),
         ],
@@ -58,7 +58,7 @@ void main(List<String> args) async {
       ),
       CappController(
         'get',
-        description: 'Get pacakges of project, (dart pub get)',
+        description: 'Get packages of project, (dart pub get)',
         run: (controller) => ProjectCommands().get(controller),
         options: [],
       ),

--- a/lib/src/cli/commands/create.dart
+++ b/lib/src/cli/commands/create.dart
@@ -89,9 +89,19 @@ class CreateProject {
 
         return savePath;
       } else {
+        CappConsole.write(
+          "Error downloading template: ${response.statusCode}",
+          CappColors.error,
+          true,
+        );
         return "";
       }
     } catch (e) {
+      CappConsole.write(
+        "Error downloading template: ${e.toString()}",
+        CappColors.error,
+        true,
+      );
       return "";
     }
   }

--- a/lib/src/cli/commands/create.dart
+++ b/lib/src/cli/commands/create.dart
@@ -6,7 +6,7 @@ import 'package:archive/archive_io.dart';
 
 class CreateProject {
   String projectUrl =
-      'https://github.com/uproid/{template}-finch-{docker}/archive/refs/heads/master.zip';
+      'https://github.com/uproid/{template}-finch{docker}/archive/refs/heads/master.zip';
   String savePath =
       '${Directory.systemTemp.path}/template_${DateTime.timestamp().microsecondsSinceEpoch}.zip';
 
@@ -43,10 +43,13 @@ class CreateProject {
       return CappConsole("Error creating this path: $path", CappColors.error);
     }
     var template = controller.getOption('template', def: 'helloworld');
+
     var repoUrl = projectUrl
         .replaceAll('{template}', template)
-        .replaceAll('{docker}', useDocker ? 'docker' : '');
-
+        .replaceAll('{docker}', useDocker ? '-docker' : '');
+    var dirName = '{template}-finch{docker}-master'
+        .replaceAll('{template}', template)
+        .replaceAll('{docker}', useDocker ? '-docker' : '');
     String pathZip = await CappConsole.progress<String>(
       "Waitng...",
       () async {
@@ -56,7 +59,7 @@ class CreateProject {
     );
 
     if (pathZip.isNotEmpty) {
-      var dirPrject = await extract(path);
+      var dirPrject = await extract(path, dirName);
       if (dirPrject.isNotEmpty) {
         await updatePacakge(
           dirPrject,
@@ -93,7 +96,7 @@ class CreateProject {
     }
   }
 
-  Future<String> extract(String dir) async {
+  Future<String> extract(String dir, String dirName) async {
     try {
       final bytes = File(savePath).readAsBytesSync();
       final archive = ZipDecoder().decodeBytes(bytes);
@@ -101,8 +104,7 @@ class CreateProject {
         final filename = file.name;
         if (file.isFile) {
           final data = file.content as List<int>;
-          var newPath =
-              filename.replaceFirst('example-finch-docker-master', '');
+          var newPath = filename.replaceFirst(dirName, '');
           File(joinPaths([dir, newPath]))
             ..createSync(recursive: true)
             ..writeAsBytesSync(data);
@@ -111,7 +113,7 @@ class CreateProject {
         }
       }
 
-      Directory(joinPaths([dir, 'example-finch-docker-master'])).deleteSync(
+      Directory(joinPaths([dir, dirName])).deleteSync(
         recursive: true,
       );
       return dir;

--- a/lib/src/cli/commands/create.dart
+++ b/lib/src/cli/commands/create.dart
@@ -6,7 +6,7 @@ import 'package:archive/archive_io.dart';
 
 class CreateProject {
   String projectUrl =
-      'https://github.com/uproid/example-finch-docker/archive/refs/heads/master.zip';
+      'https://github.com/uproid/{template}-finch-{docker}/archive/refs/heads/master.zip';
   String savePath =
       '${Directory.systemTemp.path}/template_${DateTime.timestamp().microsecondsSinceEpoch}.zip';
 
@@ -42,11 +42,15 @@ class CreateProject {
     if (!Directory(path).existsSync()) {
       return CappConsole("Error creating this path: $path", CappColors.error);
     }
+    var template = controller.getOption('template', def: 'helloworld');
+    var repoUrl = projectUrl
+        .replaceAll('{template}', template)
+        .replaceAll('{docker}', useDocker ? 'docker' : '');
 
     String pathZip = await CappConsole.progress<String>(
       "Waitng...",
       () async {
-        return downloadFile(projectUrl, savePath);
+        return downloadFile(repoUrl, savePath);
       },
       type: CappProgressType.circle,
     );

--- a/lib/src/cli/commands/create.dart
+++ b/lib/src/cli/commands/create.dart
@@ -6,7 +6,7 @@ import 'package:archive/archive_io.dart';
 
 class CreateProject {
   String projectUrl =
-      'https://github.com/uproid/{template}-finch{docker}/archive/refs/heads/master.zip';
+      'https://github.com/uproid/{template}-finch-docker/archive/refs/heads/master.zip';
   String savePath =
       '${Directory.systemTemp.path}/template_${DateTime.timestamp().microsecondsSinceEpoch}.zip';
 
@@ -42,14 +42,11 @@ class CreateProject {
     if (!Directory(path).existsSync()) {
       return CappConsole("Error creating this path: $path", CappColors.error);
     }
-    var template = controller.getOption('template', def: 'helloworld');
+    var template = controller.getOption('template', def: 'simple');
 
-    var repoUrl = projectUrl
-        .replaceAll('{template}', template)
-        .replaceAll('{docker}', useDocker ? '-docker' : '');
-    var dirName = '{template}-finch{docker}-master'
-        .replaceAll('{template}', template)
-        .replaceAll('{docker}', useDocker ? '-docker' : '');
+    var repoUrl = projectUrl.replaceAll('{template}', template);
+    var dirName =
+        '{template}-finch-docker-master'.replaceAll('{template}', template);
     String pathZip = await CappConsole.progress<String>(
       "Waitng...",
       () async {
@@ -144,13 +141,13 @@ class CreateProject {
 
     if (!useDocker) {
       final dockerFile = File(joinPaths([filePath, 'Dockerfile']));
-      dockerFile.deleteSync();
+      if (dockerFile.existsSync()) dockerFile.deleteSync();
 
       final dockerIgnore = File(joinPaths([filePath, '.dockerignore']));
-      dockerIgnore.deleteSync();
+      if (dockerIgnore.existsSync()) dockerIgnore.deleteSync();
 
       final dockerCompose = File(joinPaths([filePath, 'docker-compose.yaml']));
-      dockerCompose.deleteSync();
+      if (dockerCompose.existsSync()) dockerCompose.deleteSync();
     }
   }
 }

--- a/lib/src/finch_app.dart
+++ b/lib/src/finch_app.dart
@@ -1159,5 +1159,5 @@ class _Info {
   /// - MINOR: New features (backward compatible)
   /// - PATCH: Bug fixes (backward compatible)
   /// - PRERELEASE: Pre-release identifiers (alpha, beta, rc)
-  final String version = '1.1.1';
+  final String version = '1.1.2';
 }

--- a/lib/src/finch_app.dart
+++ b/lib/src/finch_app.dart
@@ -348,6 +348,16 @@ class FinchApp {
     await _runCommands(_args);
   }
 
+  final _helpOption = CappOption(
+    name: 'help',
+    shortName: 'h',
+    hideInHelp: true,
+    onSelect: (CappController controller) {
+      controller.writeHelp();
+      return false;
+    },
+  );
+
   /// Creates and configures the command manager for interactive CLI operations.
   /// Sets up a [CappManager] with all available server commands including:
   /// - `help` - Shows help information for all available commands
@@ -370,10 +380,15 @@ class FinchApp {
         ),
         args: args,
         controllers: [
-          CappController('clear', options: [], run: (c) async {
-            CappConsole.clear();
-            return CappConsole.empty;
-          }),
+          CappController(
+            'clear',
+            options: [_helpOption],
+            description: 'Clear console',
+            run: (c) async {
+              CappConsole.clear();
+              return CappConsole.empty;
+            },
+          ),
           CappController(
             'help',
             options: [
@@ -390,6 +405,7 @@ class FinchApp {
           CappController(
             'migrate',
             options: [
+              _helpOption,
               CappOption(
                 name: 'init',
                 shortName: 'i',
@@ -422,7 +438,7 @@ class FinchApp {
                 description: 'List migration',
               ),
             ],
-            description: 'Migration commands',
+            description: 'Mysql/Sqlite Migration commands',
             run: (c) async {
               if (c.existsOption('init')) {
                 var res = await CappConsole.progress<List<String>>(
@@ -505,6 +521,7 @@ class FinchApp {
             description:
                 'Generate widgets Dart file from templates (to dart map variable)',
             options: [
+              _helpOption,
               CappOption(
                 name: 'path',
                 shortName: 'p',
@@ -530,7 +547,7 @@ class FinchApp {
           CappController(
             'build',
             description: 'Build Project',
-            options: [],
+            options: [_helpOption],
             run: (c) async {
               await ProjectCommands().build(
                 c,
@@ -545,6 +562,7 @@ class FinchApp {
             description:
                 'Generate language Dart file from language files (to dart map variable)',
             options: [
+              _helpOption,
               CappOption(
                 name: 'path',
                 shortName: 'p',
@@ -563,7 +581,9 @@ class FinchApp {
           ),
           CappController(
             'migrate_sqlite',
+            description: 'Sqlite Migration commands',
             options: [
+              _helpOption,
               CappOption(
                 name: 'init',
                 shortName: 'i',
@@ -591,7 +611,6 @@ class FinchApp {
                 description: 'List migration',
               ),
             ],
-            description: 'Migration commands',
             run: (c) async {
               if (c.existsOption('init')) {
                 var res = await CappConsole.progress<List<String>>(
@@ -655,7 +674,9 @@ class FinchApp {
           ),
           CappController(
             'language',
+            description: 'Language management commands',
             options: [
+              _helpOption,
               CappOption(
                 name: 'list',
                 shortName: 'l',
@@ -706,42 +727,52 @@ class FinchApp {
               return CappConsole("Language commands");
             },
           ),
-          CappController('info', options: [], run: (c) async {
-            CappConsole.writeTable(
-              [
-                ['Info', 'Details'],
-                ['Finch version', info.version],
-                ['Dart Versions', Platform.version],
+          CappController(
+            'info',
+            description: 'Display server information',
+            options: [_helpOption],
+            run: (c) async {
+              CappConsole.writeTable(
                 [
-                  'Memory Usage',
-                  ConvertSize.toLogicSizeString(ProcessInfo.currentRss)
+                  ['Info', 'Details'],
+                  ['Finch version', info.version],
+                  ['Dart Versions', Platform.version],
+                  [
+                    'Memory Usage',
+                    ConvertSize.toLogicSizeString(ProcessInfo.currentRss)
+                  ],
+                  [
+                    'Max Memory Usage',
+                    ConvertSize.toLogicSizeString(ProcessInfo.maxRss)
+                  ],
+                  [
+                    'Socket Connections',
+                    (socketManager?.countClients ?? 0).toString(),
+                  ],
+                  ['Socket Users', (socketManager?.countUsers ?? 0).toString()],
                 ],
-                [
-                  'Max Memory Usage',
-                  ConvertSize.toLogicSizeString(ProcessInfo.maxRss)
-                ],
-                [
-                  'Socket Connections',
-                  (socketManager?.countClients ?? 0).toString(),
-                ],
-                ['Socket Users', (socketManager?.countUsers ?? 0).toString()],
-              ],
-              color: CappColors.info,
-            );
-            return CappConsole('\n');
-          }),
-          CappController('exit', options: [], run: (c) async {
-            await CappConsole.progress(
-              "Bye bye!",
-              () async {
-                await stop(force: true);
-                await Future.delayed(Duration(seconds: 1), () {
-                  exit(0);
-                });
-              },
-              type: CappProgressType.circle,
-            );
-          }),
+                color: CappColors.info,
+              );
+              return CappConsole('\n');
+            },
+          ),
+          CappController(
+            'exit',
+            description: 'Exit and stop the application',
+            options: [_helpOption],
+            run: (c) async {
+              await CappConsole.progress(
+                "Bye bye!",
+                () async {
+                  await stop(force: true);
+                  await Future.delayed(Duration(seconds: 1), () {
+                    exit(0);
+                  });
+                },
+                type: CappProgressType.circle,
+              );
+            },
+          ),
           ...commands,
         ],
       );

--- a/lib/src/views/htmler.dart
+++ b/lib/src/views/htmler.dart
@@ -326,7 +326,6 @@ class $JinjaComment extends JinjaTag {
 }
 
 class $CustomTag extends Tag {
-  @override
   $CustomTag(
     String tag, {
     super.attrs,
@@ -368,7 +367,6 @@ class $Html extends Tag {
 
 class $Doctype extends SingleTag {
   List<String> params = <String>[];
-  @override
   $Doctype([this.params = const ['html']]);
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: finch
 description: A fast, lightweight Dart web framework for building scalable server-side apps and APIs with MongoDB, MySQL, SQLite, WebSockets,...
 
-version: 1.1.1
+version: 1.1.2
 homepage: https://finchdart.com/
 repository: https://github.com/uproid/finch.git
 issue_tracker: https://github.com/uproid/finch/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,6 @@ repository: https://github.com/uproid/finch.git
 issue_tracker: https://github.com/uproid/finch/issues
 
 platforms:
-  web:
   linux:
   windows:
   macos:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
   base32: ^2.2.0
   archive: ^4.0.9
   http: ^1.6.0
-  capp: ^1.1.4
+  capp: ^1.1.6
   mysql_client: ^0.0.27
   sqlite3: ^3.2.0
   sqler: ^1.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,8 +30,6 @@ environment:
 
 dev_dependencies:
   build_runner: ^2.12.2
-  # build_web_compilers: ^4.0.11
-  # lints: ^5.0.0
   test: ^1.30.0
   html: ^0.15.6
   lints: ^6.1.0


### PR DESCRIPTION
Fixes #35 

Version 1.1.2
- Adding -template option to Finch CLI to create new projects with different templates
    ```bash
    finch create --template simple
    finch create -t simple
    ```
- Fixing commands help in Finch CLI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes for v1.1.2

* **New Features**
  * Added `-template` / `-t` option to the create command for generating projects from different templates.
  * Improved help command behavior across CLI.
  * Extended info command output to include Socket Users data.

* **Bug Fixes**
  * Enhanced error handling during template creation with improved feedback.
  * Added safety checks to prevent errors when managing optional files.

* **Chores**
  * Updated framework dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->