### PR TITLE
Dev 1.1.3

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,10 +5,10 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Serv",
+            "name": "Serve",
             "type": "dart",
             "request": "launch",
-            "program": "./example/lib/serv.dart",
+            "program": "./example/lib/serve.dart",
             "args": [
                 // "migration",
                 // "--init",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed bug of cookies
 - Improved the cookie options
 - Updated dependencies
+- Added `finch templates` command to show the list of available templates in GitHub #40
 
 ## 1.1.2
 - Adding -template option to Finch CLI to create new projects with different templates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
     finch migrate --rollback=2    # rolls back the last 2 migrations
     finch migrate --rollback      # rolls back the last migration
     ```
+- Fixed bug of cookies
+- Improved the cookie options
+- Updated dependencies
 
 ## 1.1.2
 - Adding -template option to Finch CLI to create new projects with different templates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
 
+## 1.1.3
+- Added new command to create migration files for mysql and sqlite databases in Finch CLI
+    ```bash
+    finch migrate --create --mysql --name create_users_table
+    finch migrate --create --sqlite --name create_users_table
+    ```
+- Fixs bugs in migration roll back command and added deep option to specify how many migrations should be rolled back in command line
+    ```bash
+    finch migrate --rollback=2    # rolls back the last 2 migrations
+    finch migrate --rollback      # rolls back the last migration
+    ```
+
 ## 1.1.2
 - Adding -template option to Finch CLI to create new projects with different templates
     ```bash

--- a/bin/finch.dart
+++ b/bin/finch.dart
@@ -165,6 +165,29 @@ void main(List<String> args) async {
         ],
       ),
       CappController(
+        'migrate',
+        description: 'Migrate project to new version of Finch',
+        options: [
+          helpOption,
+          CappOption(
+            name: 'create',
+            shortName: 'c',
+            description: 'Create new project and move files',
+          ),
+          CappOption(
+            name: 'name',
+            shortName: 'n',
+            description: 'Name of migration file (only for create option)',
+          ),
+        ],
+        run: (c) async {
+          if (c.existsOption('create')) {
+            return await ProjectCommands().createMigrateFile(c);
+          }
+          return CappConsole.empty;
+        },
+      ),
+      CappController(
         'test',
         description: 'Unit test of project, (dart test)',
         run: (controller) => ProjectCommands().test(controller),

--- a/bin/finch.dart
+++ b/bin/finch.dart
@@ -179,6 +179,11 @@ void main(List<String> args) async {
             shortName: 'n',
             description: 'Name of migration file (only for create option)',
           ),
+          CappOption(
+            name: 'sqlite',
+            shortName: 's',
+            description: 'Migrate SQLite files',
+          ),
         ],
         run: (c) async {
           if (c.existsOption('create')) {

--- a/bin/finch.dart
+++ b/bin/finch.dart
@@ -39,6 +39,12 @@ void main(List<String> args) async {
     ),
     controllers: [
       CappController(
+        'templates',
+        options: [helpOption],
+        description: 'Show the list of available templates',
+        run: (c) => ProjectCommands().getTemplateList(c),
+      ),
+      CappController(
         'create',
         description: 'Make new project',
         options: [

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,8 @@ services:
     container_name: finch
     image: uproid/finch:latest
     restart: always
+    stdin_open: true
+    tty: true
     ports:
       - "8085:8085"
       - "8181:8181"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -40,7 +40,7 @@ finch:
   widgets_type: j2.html
   # Path of migrations files for different databases
   mysql_migrate:
-    path: ./lib/mysql/migrations
+    path: ./migrations
   # Path of migrations files for different databases
   sqlite_migrate:
     path: ./lib/sqlite/

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -43,7 +43,7 @@ finch:
     path: ./migrations
   # Path of migrations files for different databases
   sqlite_migrate:
-    path: ./lib/sqlite/
+    path: ./migrations_sqlite
   build_output: ./build_example
   public_path: ./public
   

--- a/lib/src/cli/commands/commands.dart
+++ b/lib/src/cli/commands/commands.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 import 'package:capp/capp.dart';
+import 'package:finch/model_less.dart';
+import 'package:finch/src/db/mysql/mysql_migration.dart';
 import 'package:finch/src/tools/convertor/language_to_dart.dart';
 import 'package:finch/src/tools/convertor/widget_to_dart.dart';
 import 'package:finch/src/tools/extensions/directory.dart';
@@ -10,14 +12,12 @@ import 'package:yaml/yaml.dart';
 import 'package:path/path.dart' as p;
 
 class ProjectCommands {
-  Map finchConfigs = {};
+  Map<String, dynamic> finchConfigs = {};
   ProjectCommands() {
     var pubspecPath = _findPubspecPath(Directory.current.path);
     var pubspec = _loadPubspec(pubspecPath);
     var finchYaml = pubspec['finch'] as YamlMap?;
-    for (var key in finchYaml?.keys ?? []) {
-      finchConfigs[key] = finchYaml?[key];
-    }
+    finchConfigs = _reformYamlToMap(finchYaml);
   }
 
   Future<CappConsole> get(CappController controller) async {
@@ -381,6 +381,30 @@ class ProjectCommands {
     );
   }
 
+  Future<CappConsole> createMigrateFile(CappController c) async {
+    var defaultMigratePath = _pubspec('mysql_migrate/path');
+    var path = c.getOption('path', def: defaultMigratePath);
+    if (path.isEmpty) {
+      return CappConsole(
+        "The path of migration directory is not found. please set it in pubspec.yaml \n\nfinch:\n\tmysql_migrate:\n\t\tpath: ./migrate\n",
+        CappColors.error,
+      );
+    }
+
+    var name = c.getOption('name', def: '');
+    if (name.isEmpty) {
+      name = CappConsole.read("Enter migration name:", isRequired: true);
+    }
+    var res = await CappConsole.progress<String>(
+      "Creating migration...",
+      () async => MysqlMigration.migrateCreate(
+        name: name,
+        migrationPath: path,
+      ),
+    );
+    return CappConsole(res);
+  }
+
   String _findPubspecPath(String startPath) {
     var pubspecFile = File(joinPaths([startPath, 'pubspec.yaml']));
     if (pubspecFile.existsSync()) {
@@ -394,5 +418,22 @@ class ProjectCommands {
     var content = pubspecFile.readAsStringSync();
     var pubspec = loadYaml(content);
     return pubspec;
+  }
+
+  String _pubspec(String path, {String def = ''}) {
+    return finchConfigs.navigation<String>(path: path, def: def);
+  }
+
+  Map<String, dynamic> _reformYamlToMap(YamlMap? finchYaml) {
+    var res = <String, dynamic>{};
+    if (finchYaml == null) return res;
+    finchYaml.forEach((key, value) {
+      if (value is YamlMap) {
+        res[key] = _reformYamlToMap(value);
+      } else {
+        res[key] = value;
+      }
+    });
+    return res;
   }
 }

--- a/lib/src/cli/commands/commands.dart
+++ b/lib/src/cli/commands/commands.dart
@@ -382,11 +382,18 @@ class ProjectCommands {
   }
 
   Future<CappConsole> createMigrateFile(CappController c) async {
-    var defaultMigratePath = _pubspec('mysql_migrate/path');
+    var isSqlite = c.existsOption('sqlite');
+
+    var defaultMigratePath = _pubspec(
+      isSqlite ? 'sqlite_migrate/path' : 'mysql_migrate/path',
+    );
     var path = c.getOption('path', def: defaultMigratePath);
+
     if (path.isEmpty) {
       return CappConsole(
-        "The path of migration directory is not found. please set it in pubspec.yaml \n\nfinch:\n\tmysql_migrate:\n\t\tpath: ./migrate\n",
+        "The path of migration directory is not found."
+        " please set it in pubspec.yaml"
+        " \n\nfinch:\n\tmysql_migrate:\n\t\tpath: ./migrate\n",
         CappColors.error,
       );
     }

--- a/lib/src/cli/commands/commands.dart
+++ b/lib/src/cli/commands/commands.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 import 'package:capp/capp.dart';
 import 'package:finch/model_less.dart';
@@ -10,6 +11,7 @@ import 'package:finch/finch_app.dart';
 import 'package:archive/archive_io.dart';
 import 'package:yaml/yaml.dart';
 import 'package:path/path.dart' as p;
+import 'package:http/http.dart' as http;
 
 class ProjectCommands {
   Map<String, dynamic> finchConfigs = {};
@@ -442,5 +444,49 @@ class ProjectCommands {
       }
     });
     return res;
+  }
+
+  Future<CappConsole> getTemplateList(CappController c) async {
+    var res = [
+      ['#', 'Key', 'Github', 'Description'],
+    ];
+    var githubUrl = 'https://api.github.com/users/uproid/repos';
+    var request = await CappConsole.progress(
+      "Fetching templates from GitHub",
+      () async => http.get(Uri.parse(githubUrl)),
+      type: CappProgressType.timer,
+    );
+
+    if (request.statusCode == 200) {
+      var repos = jsonDecode(request.body) as List<dynamic>;
+      int index = 0;
+      for (var repo in repos) {
+        var name = repo['name'] as String;
+        if (name.contains('-finch-docker')) {
+          var description = repo['description'] as String? ?? '';
+          var htmlUrl = repo['html_url'] as String;
+          res.add([
+            (++index).toString(),
+            name.replaceAll('-finch-docker', ''),
+            htmlUrl,
+            '${description.substring(
+              0,
+              description.length > 20 ? 20 : description.length,
+            )}...',
+          ]);
+        }
+      }
+    } else {
+      return CappConsole(
+        "Failed to fetch templates from GitHub. Status code: ${request.statusCode}",
+        CappColors.error,
+      );
+    }
+    CappConsole.writeTable(res, color: CappColors.info);
+    CappConsole.write(
+      "* Use 'finch create --template <key>' to create project with template",
+      CappColors.success,
+    );
+    return CappConsole.empty;
   }
 }

--- a/lib/src/db/mysql/mysql_migration.dart
+++ b/lib/src/db/mysql/mysql_migration.dart
@@ -167,12 +167,13 @@ class MysqlMigration {
   /// - Rollback SQL statements (-- ## ROLL BACK:)
   /// The filename format is: `{timestamp}_migration.sql`
   /// Returns a success message with the path of the created file.
-  Future<String> migrateCreate({
+  static Future<String> migrateCreate({
     String name = '',
+    String? migrationPath,
   }) async {
     File file = File(
       path.join(
-        pathTo(FinchApp.config.pathMigrationMySQL),
+        migrationPath ?? pathTo(FinchApp.config.pathMigrationMySQL),
         '${DateTime.now().millisecondsSinceEpoch}_'
         '${name.isNotEmpty ? '${name.toSlug().replaceAll('-', '_')}_' : ''}'
         'migration.sql',

--- a/lib/src/finch_app.dart
+++ b/lib/src/finch_app.dart
@@ -795,7 +795,7 @@ class FinchApp {
 
     return _getCommandManager(args).processWhile(
       initArgs: args,
-      promptLabel: 'Finch> ',
+      appLabel: () => 'Finch> ',
     );
   }
 

--- a/lib/src/finch_app.dart
+++ b/lib/src/finch_app.dart
@@ -486,8 +486,7 @@ class FinchApp {
 
                 var res = await CappConsole.progress<String>(
                   "Creating migration...",
-                  () async =>
-                      MysqlMigration(mysqlDriver).migrateCreate(name: name),
+                  () async => MysqlMigration.migrateCreate(name: name),
                 );
                 return CappConsole(res);
               }
@@ -1190,5 +1189,5 @@ class _Info {
   /// - MINOR: New features (backward compatible)
   /// - PATCH: Bug fixes (backward compatible)
   /// - PRERELEASE: Pre-release identifiers (alpha, beta, rc)
-  final String version = '1.1.2';
+  final String version = '1.1.3';
 }

--- a/lib/src/render/request.dart
+++ b/lib/src/render/request.dart
@@ -1674,15 +1674,24 @@ class Request {
     String value, {
     Duration? duration,
     bool safe = true,
+    bool secure = false,
+    bool httpOnly = false,
+    SameSite? sameSite,
+    String path = '/',
+    DateTime? expires,
+    String? domain,
   }) {
     key = fixCookieName(key);
     removeCookie(key);
     value = safe ? value.toSafe(FinchApp.config.cookiePassword) : value;
     var cookie = Cookie(key, value);
     cookie.maxAge = duration?.inSeconds;
-    cookie.path = '/';
-    cookie.secure = false;
-    cookie.httpOnly = false;
+    cookie.path = path;
+    cookie.secure = secure;
+    cookie.httpOnly = httpOnly;
+    cookie.sameSite = sameSite;
+    cookie.expires = expires;
+    cookie.domain = domain;
     _rq.response.cookies.add(cookie);
     _rq.cookies.add(cookie);
   }
@@ -1690,10 +1699,17 @@ class Request {
   /// Removes a cookie by setting its value to an empty string and expiration to a past date.
   ///
   /// [key] - The name of the cookie to be removed.
-  void removeCookie(String key) {
+  void removeCookie(String key, {String path = '/'}) {
     key = fixCookieName(key);
     _rq.cookies.removeWhere((element) => element.name == key);
     _rq.response.cookies.removeWhere((element) => element.name == key);
+
+    // Add expired cookie to tell browser to remove it
+    var cookie = Cookie(key, '');
+    cookie.maxAge = 0;
+    cookie.expires = DateTime.now().subtract(const Duration(days: 1));
+    cookie.path = path;
+    _rq.response.cookies.add(cookie);
   }
 
   /// Constructs a full URL by combining a base URL with a subpath and optional query parameters.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: finch
 description: A fast, lightweight Dart web framework for building scalable server-side apps and APIs with MongoDB, MySQL, SQLite, WebSockets,...
 
-version: 1.1.2
+version: 1.1.3
 homepage: https://finchdart.com/
 repository: https://github.com/uproid/finch.git
 issue_tracker: https://github.com/uproid/finch/issues
@@ -51,9 +51,9 @@ dependencies:
   base32: ^2.2.0
   archive: ^4.0.9
   http: ^1.6.0
-  capp: ^1.1.6
+  capp: ^1.1.7
   mysql_client: ^0.0.27
-  sqlite3: ^3.2.0
+  sqlite3: ^3.3.0
   sqler: ^1.2.0
   html_unescape: ^2.0.0
   yaml: ^3.1.3
@@ -63,4 +63,6 @@ executables:
 finch:
   serve: ./example/lib/serve.dart
   app: ./example/lib/serve.dart
+  mysql_migrate:
+    path: ./example/migrations
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,9 +51,9 @@ dependencies:
   base32: ^2.2.0
   archive: ^4.0.9
   http: ^1.6.0
-  capp: ^1.1.7
+  capp: ^1.1.8
   mysql_client: ^0.0.27
-  sqlite3: ^3.3.0
+  sqlite3: ^3.3.1
   sqler: ^1.2.0
   html_unescape: ^2.0.0
   yaml: ^3.1.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,4 +65,6 @@ finch:
   app: ./example/lib/serve.dart
   mysql_migrate:
     path: ./example/migrations
+  sqlite_migrate:
+    path: ./example/migrations_sqlite
 

--- a/test/finch_server_test.dart
+++ b/test/finch_server_test.dart
@@ -33,6 +33,29 @@ void main() async {
         index: () => rq.renderString(text: "TEST"),
         children: [
           FinchRoute(
+            path: '/test_cookies/list',
+            index: () {
+              rq.addCookie('SYSTEM_TEST', 'TEST_VALUE_2', safe: false);
+              return rq.renderDataParam(data: {
+                'cookies': rq.cookies,
+                'cookies_res': rq.response.cookies,
+              });
+            },
+          ),
+          FinchRoute(
+            path: '/test_cookies/delete_cookies',
+            index: () {
+              var key = rq.get<String>('key');
+              Console.i("Deleting cookie with key: $key");
+              rq.removeCookie(key);
+              return rq.renderDataParam(data: {
+                'cookies': rq.cookies,
+                'cookies_res': rq.response.cookies,
+                'key_to_delete': key,
+              });
+            },
+          ),
+          FinchRoute(
             path: '/advanced_form',
             methods: Methods.GET_ONLY,
             index: () async {
@@ -266,6 +289,47 @@ void main() async {
   });
 
   group("Finch Server Test", () {
+    test("Test List Cookies", () async {
+      var req = await http.get(
+        Uri.parse("http://localhost:${httpServer.port}/test_cookies/list"),
+        headers: {
+          'Cookie': 'test_cookie=TEST_VALUE;',
+        },
+      );
+
+      expect(
+        req.body,
+        contains('test_cookie=TEST_VALUE;'),
+        reason: "Request cookies should contain 'test_cookie=TEST_VALUE;'",
+      );
+      expect(
+        req.body,
+        contains('SYSTEM_TEST=TEST_VALUE_2;'),
+        reason: "Request cookies should contain 'SYSTEM_TEST=TEST_VALUE_2;'",
+      );
+    });
+
+    test("Test Delete Cookie by Backend", () async {
+      var req = await http.get(
+        Uri.parse(
+          "http://localhost:${httpServer.port}/test_cookies/delete_cookies?key=test_cookie",
+        ),
+        headers: {
+          'Cookie': 'test_cookie=TEST_VALUE;TEST_COOKIE_2=TEST_VALUE_2;',
+        },
+      );
+      expect(
+        false,
+        req.body.contains('test_cookie=TEST_VALUE;'),
+        reason: "Request cookies should not contain 'test_cookie=TEST_VALUE;'",
+      );
+      expect(
+        req.body,
+        contains('TEST_COOKIE_2=TEST_VALUE_2;'),
+        reason: "Request cookies should contain 'TEST_COOKIE_2=TEST_VALUE_2;'",
+      );
+    });
+
     test("Test 200", () async {
       var req = await http.get(
         Uri.parse("http://localhost:${httpServer.port}"),


### PR DESCRIPTION
## 1.1.3
- Added new command to create migration files for mysql and sqlite databases in Finch CLI
    ```bash
    finch migrate --create --mysql --name create_users_table
    finch migrate --create --sqlite --name create_users_table
    ```
- Fixs bugs in migration roll back command and added deep option to specify how many migrations should be rolled back in command line
    ```bash
    finch migrate --rollback=2    # rolls back the last 2 migrations
    finch migrate --rollback      # rolls back the last migration
    ```
- Fixed bug of cookies
- Improved the cookie options
- Updated dependencies
- Added `finch templates` command to show the list of available templates in GitHub #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `finch migrate` command supporting MySQL and SQLite migrations with `--create` option and custom naming
  * Added `finch templates` command to browse available project templates from GitHub
  * Enhanced cookie management with additional configuration options (secure, httpOnly, sameSite, path, expires, domain)

* **Bug Fixes**
  * Fixed migration rollback functionality and cookie removal

* **Chores**
  * Updated dependencies
  * Version bumped to 1.1.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->