### PR TITLE
Fixed issue #58, while using migrate -r and migrate -i

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## 1.3.2
+- [#58](https://github.com/uproid/finch/issues/58) Fixes #58: Resolved issues in the migrate -i and migrate -r processes. The migration process will now stop if a MySQL error occurs.
+- fixing issue for examples
+
 ## 1.3.1
 - [#54](https://github.com/uproid/finch/issues/54) Fixed a bug in the route caching functionality where responses were not being properly cached and retrieved based
 

--- a/example/lib/route/web_route.dart
+++ b/example/lib/route/web_route.dart
@@ -120,6 +120,10 @@ Future<List<FinchRoute>> getWebRoute(Request rq) async {
           path: 'route',
           methods: Methods.ONLY_GET,
           index: homeController.exampleRoute,
+        ).cache(
+          cacheDuration: Duration(minutes: 10),
+          cacheType: [CacheParam.path, CacheParam.method, CacheParam.language],
+          cacheSource: CacheSource.file,
         ),
         FinchRoute(
           key: 'root.socket',
@@ -197,10 +201,6 @@ Future<List<FinchRoute>> getWebRoute(Request rq) async {
       index: homeController.info,
       apiDoc: ApiDocuments.info,
       middlewares: [testMiddleware],
-    ).cache(
-      cacheDuration: Duration(minutes: 10),
-      cacheType: [CacheParam.path, CacheParam.method, CacheParam.language],
-      cacheSource: CacheSource.file,
     ),
     FinchRoute(
       key: 'root.person.post',

--- a/lib/src/db/mysql/mysql_migration.dart
+++ b/lib/src/db/mysql/mysql_migration.dart
@@ -86,12 +86,18 @@ class MysqlMigration {
       var sqlContent = await file.readAsString();
       sqlContent = sqlContent.split('-- ## ROLL BACK:')[0];
       if (sqlContent.isEmpty) continue;
-      await db.executeString(sqlContent);
-      executedFiles.add(filename);
-      await migrationTable.insert(db, {
-        'file': QVar(filename),
-        'sort': QVar(DateTime.now().millisecondsSinceEpoch.toString()),
-      });
+      var res = await db.executeString(sqlContent);
+      if (res.success) {
+        executedFiles.add(filename);
+        await migrationTable.insert(db, {
+          'file': QVar(filename),
+          'sort': QVar(DateTime.now().millisecondsSinceEpoch.toString()),
+        });
+      } else {
+        throw Exception(
+          'Error executing migration file: $filename\nError message: ${res.errorMsg}',
+        );
+      }
     }
 
     if (executedFiles.isEmpty) {
@@ -142,7 +148,13 @@ class MysqlMigration {
       var rollbackContent = sqlContent.split('-- ## ROLL BACK:')[1];
       if (rollbackContent.isEmpty) continue;
 
-      await db.executeString(rollbackContent);
+      var res = await db.executeString(rollbackContent);
+      if (!res.success) {
+        throw Exception(
+          'Error executing rollback for migration file: $filename\nError message: ${res.errorMsg}',
+        );
+      }
+
       await migrationTable.delete(
         db,
         Sqler()

--- a/lib/src/finch_app.dart
+++ b/lib/src/finch_app.dart
@@ -443,7 +443,14 @@ class FinchApp {
               if (c.existsOption('init')) {
                 var res = await CappConsole.progress<List<String>>(
                   "Initializing migration...",
-                  () async => MysqlMigration(mysqlDriver).migrateInit(),
+                  () async =>
+                      MysqlMigration(mysqlDriver).migrateInit().catchError((e) {
+                    CappConsole.write(
+                      "\n\n$e\n",
+                      CappColors.error,
+                    );
+                    return <String>[];
+                  }),
                 );
                 var index = 1;
                 var table = res.map((e) => [(index++).toString(), e]).toList();
@@ -495,7 +502,15 @@ class FinchApp {
                 int deep = c.getOption('rollback', def: '1').toInt(def: 1);
                 var res = await CappConsole.progress<String>(
                   "Rolling back migration...",
-                  () async => MysqlMigration(mysqlDriver).migrateRollback(deep),
+                  () async => MysqlMigration(mysqlDriver)
+                      .migrateRollback(deep)
+                      .catchError((e) {
+                    CappConsole.write(
+                      "\n\n$e\n",
+                      CappColors.error,
+                    );
+                    return "Error rolling back migration";
+                  }),
                 );
                 return CappConsole(res);
               }
@@ -1189,5 +1204,5 @@ class _Info {
   /// - MINOR: New features (backward compatible)
   /// - PATCH: Bug fixes (backward compatible)
   /// - PRERELEASE: Pre-release identifiers (alpha, beta, rc)
-  final String version = '1.3.1';
+  final String version = '1.3.2';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: finch
 description: Finch is a fast, lightweight Dart framework for building scalable server-side web apps, REST APIs, databases, WebSockets, and MCP servers
 
-version: 1.3.1
+version: 1.3.2
 homepage: https://finchdart.com/
 repository: https://github.com/uproid/finch.git
 issue_tracker: https://github.com/uproid/finch/issues


### PR DESCRIPTION
Fixes #58: Resolved issues in the migrate -i and migrate -r processes. The migration process will now stop if a MySQL error occurs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MySQL migrations now halt on errors and report error details instead of continuing silently
  * Migration rollback operations now validate execution results before completing

* **Improvements**
  * Enhanced error reporting and handling for migration command failures

* **Chores**
  * Version updated to 1.3.2

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uproid/finch/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->