### PR TITLE
Dev 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## 1.5.2-dev.1
+- Removed the `Request rq` parameter from `FinchApp.addRouting()` callbacks; request data remains available through `Context.rq` inside route handlers
+- Improved route URL generation and method checks by passing request-specific values explicitly
+
 ## 1.5.1
 - Upgraded MCP support to MCP 2.0 (`mcp_models: 2.0.0`): replaced `initialize`/`notifications/initialized` handling with the new `server/discover` method and `DiscoverResult` response
 - Added `make:migration` command to create SQL or Dart migration files from the CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 
-## 1.5.2-dev.1
+## 1.5.2
 - Removed the `Request rq` parameter from `FinchApp.addRouting()` callbacks; request data remains available through `Context.rq` inside route handlers
 - Improved route URL generation and method checks by passing request-specific values explicitly
+- Fix issue [#80](https://github.com/uproid/finch/issues/80): Support the Previous MCP Protocol Version with an Extended Deprecation Period
 
 ## 1.5.1
 - Upgraded MCP support to MCP 2.0 (`mcp_models: 2.0.0`): replaced `initialize`/`notifications/initialized` handling with the new `server/discover` method and `DiscoverResult` response

--- a/example/lib/controllers/mcp_controller.dart
+++ b/example/lib/controllers/mcp_controller.dart
@@ -1,7 +1,7 @@
+import 'package:finch/mcp.dart';
 import '../app.dart';
 import '../db/mysql/mysql_books.dart';
 import 'package:finch/finch_model_less.dart';
-import 'package:finch/mcp.dart';
 
 class McpServerBooksController extends McpServerController {
   final bookSchema = {

--- a/example/lib/core/local_events.dart
+++ b/example/lib/core/local_events.dart
@@ -4,7 +4,7 @@ import 'package:finch/finch_tools.dart';
 
 var localEvents = <String, Object>{
   'route': (String key) {
-    return FinchRoute.getByKey(key)?.getUrl() ?? '';
+    return FinchRoute.getByKey(key)?.getUrl(Context.rq) ?? '';
   },
   'hasFlash': () {
     return Context.rq.get('flash') != null;

--- a/example/lib/route/web_route.dart
+++ b/example/lib/route/web_route.dart
@@ -16,7 +16,7 @@ final includeController = IncludeJsController();
 final apiController = ApiController(title: "API Documentation", app: app);
 final testMiddleware = TestMiddleware();
 
-Future<List<FinchRoute>> getWebRoute(Request rq) async {
+Future<List<FinchRoute>> getWebRoute() async {
   var paths = [
     FinchRoute(
       key: 'root.sse',

--- a/lib/mcp.dart
+++ b/lib/mcp.dart
@@ -1,4 +1,4 @@
 library;
 
 export 'src/controllers/mcp_server_controller.dart';
-export 'package:mcp_models/mcp_models.dart';
+export 'package:mcp_models/mcp_models_v2026.dart';

--- a/lib/src/controllers/mcp_server_controller.dart
+++ b/lib/src/controllers/mcp_server_controller.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'package:finch/finch_console.dart';
 import 'package:finch/finch_route.dart';
 import 'package:finch/finch_tools.dart';
 import 'package:mcp_models/mcp_models_v2026.dart' as v26;

--- a/lib/src/controllers/mcp_server_controller.dart
+++ b/lib/src/controllers/mcp_server_controller.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
+import 'package:finch/finch_console.dart';
 import 'package:finch/finch_route.dart';
 import 'package:finch/finch_tools.dart';
-import 'package:mcp_models/mcp_models.dart';
+import 'package:mcp_models/mcp_models_v2026.dart' as v26;
+import 'package:mcp_models/mcp_models_v2025.dart' as v25;
 
 /// Abstract base for MCPP-compatible controllers in the Finch framework.
 ///
@@ -33,15 +35,15 @@ import 'package:mcp_models/mcp_models.dart';
 /// }
 /// ```
 abstract class McpServerController extends Controller {
-  McpBuilder? _mcpBuilder;
+  v26.McpBuilder? _mcpBuilder;
 
   /// Lazily built once per controller instance.
   /// Since Finch controllers are per-request, [configure] is always called
   /// with the live [rq] object, making request-scoped values (e.g. `rq.url()`)
   /// safe to use inside [configure].
-  McpBuilder get _registry {
+  v26.McpBuilder get _registry {
     if (_mcpBuilder == null) {
-      _mcpBuilder = McpBuilder();
+      _mcpBuilder = v26.McpBuilder();
       configure(_mcpBuilder!);
     }
     return _mcpBuilder!;
@@ -51,16 +53,50 @@ abstract class McpServerController extends Controller {
   ///
   /// Implement this method to register tools, resources, prompts, resource
   /// templates, and custom method handlers via [McpBuilder].
-  void configure(McpBuilder mcp);
+  void configure(v26.McpBuilder mcp);
+
+  McpProtocolVersion _findRequestVersion(Map<String, Object?> rpcRequest) {
+    // Real MCP clients never send a top-level "version" field. The actual
+    // signal is the `Mcp-Protocol-Version` header (Streamable HTTP transport,
+    // sent on every request after initialize), `params.protocolVersion`
+    // (sent on `initialize`), or `params._meta`'s protocolVersion key (sent
+    // per-request by 2026-07-28 clients).
+    String? stringVersion = rq.headers.value('mcp-protocol-version');
+
+    final params = rpcRequest['params'];
+    if (params is Map) {
+      stringVersion ??= params['protocolVersion']?.toString();
+
+      final meta = params['_meta'];
+      if (meta is Map) {
+        stringVersion ??=
+            meta['io.modelcontextprotocol/protocolVersion']?.toString();
+      }
+    }
+
+    stringVersion ??= '2025-11-25';
+    if (stringVersion.contains('2026')) {
+      return McpProtocolVersion.v2026_07_28;
+    }
+    return McpProtocolVersion.v2025_11_25;
+  }
 
   @override
   Future<String> index() async {
     final payload = rq.getAll().removeAll(['POST', 'GET', 'FILE']);
+    var version = _findRequestVersion(payload);
+    if (version == McpProtocolVersion.v2026_07_28) {
+      return _renderV26(payload);
+    }
+    return _renderV25(payload);
+  }
+
+  Future<String> _renderV25(Map<String, Object?> payload) async {
     try {
-      final JSONRPCRequest rpcRequest = JSONRPCRequest.toMCP(payload);
+      final v25.JSONRPCRequest rpcRequest = v25.JSONRPCRequest.toMCP(payload);
 
       final stream = Stream.fromFuture(Future(() async {
-        final response = await _dispatch(
+        final response = await _dispatchV25(
           rpcRequest.method,
           rpcRequest.id,
           payload,
@@ -69,9 +105,9 @@ abstract class McpServerController extends Controller {
       }));
       return await rq.renderSSE(stream);
     } catch (e) {
-      final errorResponse = JSONRPCErrorResponse(
+      final errorResponse = v25.JSONRPCErrorResponse(
         id: payload['id']?.toString() ?? '-1',
-        error: Error(code: -32600, message: 'Invalid Request: $e'),
+        error: v25.Error(code: -32600, message: 'Invalid Request: $e'),
       );
 
       final stream = Stream.fromIterable([
@@ -79,14 +115,38 @@ abstract class McpServerController extends Controller {
           data: FinchJson.jsonEncoder(errorResponse.toMap()),
         ),
       ]);
-
       return await rq.renderSSE(stream, status: 400);
     }
   }
 
-  // ── Central dispatcher ────────────────────────────────────────────────────
+  Future<String> _renderV26(Map<String, Object?> payload) async {
+    try {
+      final v26.JSONRPCRequest rpcRequest = v26.JSONRPCRequest.toMCP(payload);
+      final stream = Stream.fromFuture(Future(() async {
+        final response = await _dispatchV26(
+          rpcRequest.method,
+          rpcRequest.id,
+          payload,
+        );
+        return SSE(data: FinchJson.jsonEncoder(response.toMap()));
+      }));
+      return await rq.renderSSE(stream);
+    } catch (e) {
+      final errorResponse = v26.JSONRPCErrorResponse(
+        id: payload['id']?.toString() ?? '-1',
+        error: v26.Error(code: -32600, message: 'Invalid Request: $e'),
+      );
 
-  Future<MCP> _dispatch(
+      final stream = Stream.fromIterable([
+        SSE(
+          data: FinchJson.jsonEncoder(errorResponse.toMap()),
+        ),
+      ]);
+      return await rq.renderSSE(stream, status: 400);
+    }
+  }
+
+  Future<v25.MCP> _dispatchV25(
     String method,
     String id,
     Map<String, Object?> payload,
@@ -99,110 +159,198 @@ abstract class McpServerController extends Controller {
 
     switch (method) {
       case '':
-        return JSONRPCResultResponse(result: EmptyResult());
+        return v25.JSONRPCResultResponse(result: v25.EmptyResult());
 
-      case 'server/discover':
-        return _buildDiscoverResponse(id, registry);
+      case 'initialize':
+        return _buildInitializeResponse(id, registry);
 
       case 'tools/list':
-        return ListToolsResultResponse(
+        return v26.ListToolsResultResponse(
             id: id, result: registry.buildToolsResult());
 
       case 'tools/call':
         return await _dispatchToolCall(payload, id, registry);
 
       case 'resources/list':
-        return ListResourcesResultResponse(
+        return v26.ListResourcesResultResponse(
             id: id, result: registry.buildResourcesResult());
 
       case 'resources/read':
         return await _dispatchResourceRead(payload, id, registry);
 
       case 'resources/templates/list':
-        return ListResourceTemplatesResultResponse(
+        return v26.ListResourceTemplatesResultResponse(
             id: id, result: registry.buildResourceTemplatesResult());
 
       case 'prompts/list':
-        return ListPromptsResultResponse(
+        return v26.ListPromptsResultResponse(
+            id: id, result: registry.buildPromptsResult());
+
+      case 'prompts/get':
+        return await _dispatchPromptGet(payload, id, registry);
+
+      case 'notifications/initialized':
+        return v25.JSONRPCNotification(method: 'notifications/initialized');
+
+      case 'logging/setLevel':
+        return v25.SetLevelResultResponse(id: id, result: v25.Result());
+
+      default:
+        return v25.JSONRPCErrorResponse(
+          id: id,
+          error: v25.Error(code: -32601, message: 'Method not found: $method'),
+        );
+    }
+  }
+
+  v25.MCP _buildInitializeResponse(String id, v26.McpBuilder registry) {
+    return v25.InitializeResultResponse(
+      id: id,
+      result: v25.InitializeResult(
+        capabilities: v25.ServerCapabilities({
+          'tools': registry.buildToolsResult().toMap(),
+          'resources': {'list': true, 'read': true},
+          'prompts': {'list': true, 'get': true},
+        }),
+        serverInfo: v25.Implementation(
+          name: 'finch-mcp-server',
+          version: '1.0.0',
+        ),
+      ),
+    );
+  }
+
+  Future<v26.MCP> _dispatchV26(
+    String method,
+    String id,
+    Map<String, Object?> payload,
+  ) async {
+    final registry = _registry;
+    // Custom handlers registered via mcp.method() take priority.
+    final customHandler = registry.methodHandler(method);
+    if (customHandler != null) return await customHandler(payload);
+
+    switch (method) {
+      case '':
+        return v26.JSONRPCResultResponse(result: v26.EmptyResult());
+
+      case 'server/discover':
+        var res = _buildDiscoverResponse(id, registry);
+        return res;
+
+      case 'tools/list':
+        return v26.ListToolsResultResponse(
+            id: id, result: registry.buildToolsResult());
+
+      case 'tools/call':
+        return await _dispatchToolCall(payload, id, registry);
+
+      case 'resources/list':
+        return v26.ListResourcesResultResponse(
+            id: id, result: registry.buildResourcesResult());
+
+      case 'resources/read':
+        return await _dispatchResourceRead(payload, id, registry);
+
+      case 'resources/templates/list':
+        return v26.ListResourceTemplatesResultResponse(
+            id: id, result: registry.buildResourceTemplatesResult());
+
+      case 'prompts/list':
+        return v26.ListPromptsResultResponse(
             id: id, result: registry.buildPromptsResult());
 
       case 'prompts/get':
         return await _dispatchPromptGet(payload, id, registry);
 
       default:
-        return JSONRPCErrorResponse(
+        return v26.JSONRPCErrorResponse(
           id: id,
-          error: Error(code: -32601, message: 'Method not found: $method'),
+          error: v26.Error(code: -32601, message: 'Method not found: $method'),
         );
     }
   }
 
-  // ── Built-in handlers ────────────────────────────────────────────────────
-
-  MCP _buildDiscoverResponse(String id, McpBuilder registry) {
-    return DiscoverResultResponse(
+  v26.MCP _buildDiscoverResponse(String id, v26.McpBuilder registry) {
+    return v26.DiscoverResultResponse(
       id: id,
-      result: DiscoverResult(
+      result: v26.DiscoverResult(
         supportedVersions: const ['2026-07-28'],
-        capabilities: ServerCapabilities({
+        capabilities: v26.ServerCapabilities({
           'tools': registry.buildToolsResult().toMap(),
           'resources': {'list': true, 'read': true},
           'prompts': {'list': true, 'get': true},
         }),
         ttlMs: const Duration(minutes: 5).inMilliseconds,
-        cacheScope: CacheScope.public,
+        cacheScope: v26.CacheScope.public,
       ),
     );
   }
 
-  Future<MCP> _dispatchToolCall(
+  Future<v26.MCP> _dispatchToolCall(
     Map<String, Object?> payload,
     String id,
-    McpBuilder registry,
+    v26.McpBuilder registry,
   ) async {
-    final request = CallToolRequest.toMCP(payload);
+    final request = v26.CallToolRequest.toMCP(payload);
     final handler = registry.toolHandler(request.params.name);
     if (handler == null) {
-      return JSONRPCErrorResponse(
+      return v26.JSONRPCErrorResponse(
         id: id,
-        error: Error(
+        error: v26.Error(
             code: -32601, message: 'Tool not found: ${request.params.name}'),
       );
     }
-    return CallToolResultResponse(id: id, result: await handler(request));
+    return v26.CallToolResultResponse(id: id, result: await handler(request));
   }
 
-  Future<MCP> _dispatchResourceRead(
+  Future<v26.MCP> _dispatchResourceRead(
     Map<String, Object?> payload,
     String id,
-    McpBuilder registry,
+    v26.McpBuilder registry,
   ) async {
-    final request = ReadResourceRequest.toMCP(payload);
+    final request = v26.ReadResourceRequest.toMCP(payload);
     final handler = registry.resourceHandlerByUri(request.params.uri);
     if (handler == null) {
-      return JSONRPCErrorResponse(
+      return v26.JSONRPCErrorResponse(
         id: id,
-        error: Error(
+        error: v26.Error(
             code: -32601, message: 'Resource not found: ${request.params.uri}'),
       );
     }
-    return ReadResourceResultResponse(id: id, result: await handler(request));
+    return v26.ReadResourceResultResponse(
+        id: id, result: await handler(request));
   }
 
-  Future<MCP> _dispatchPromptGet(
+  Future<v26.MCP> _dispatchPromptGet(
     Map<String, Object?> payload,
     String id,
-    McpBuilder registry,
+    v26.McpBuilder registry,
   ) async {
-    final request = GetPromptRequest.toMCP(payload);
+    final request = v26.GetPromptRequest.toMCP(payload);
     final handler = registry.promptHandler(request.params.name);
     if (handler == null) {
-      return JSONRPCErrorResponse(
+      return v26.JSONRPCErrorResponse(
         id: id,
-        error: Error(
+        error: v26.Error(
             code: -32601, message: 'Prompt not found: ${request.params.name}'),
       );
     }
-    return GetPromptResultResponse(id: id, result: await handler(request));
+    return v26.GetPromptResultResponse(id: id, result: await handler(request));
   }
+}
+
+enum McpProtocolVersion {
+  v2025_11_25(
+    version: '2025-11-25',
+  ),
+  v2026_07_28(
+    version: '2026-07-28',
+  );
+
+  final String version;
+
+  const McpProtocolVersion({
+    required this.version,
+  });
 }

--- a/lib/src/core/context.dart
+++ b/lib/src/core/context.dart
@@ -13,6 +13,10 @@ class Context {
     return context as Request;
   }
 
+  static Request? get rqOrNull {
+    return Zone.current[_requestKey] as Request?;
+  }
+
   static bool get hasCurrent {
     return Zone.current[_requestKey] != null;
   }

--- a/lib/src/finch_app.dart
+++ b/lib/src/finch_app.dart
@@ -83,7 +83,7 @@ class FinchApp {
   static late FinchConfigs config;
 
   /// A list of functions that return a [Future] containing a list of [FinchRoute] based on the [Request].
-  final List<Future<List<FinchRoute>> Function(Request rq)> _webRoutes = [];
+  final List<Future<List<FinchRoute>> Function()> _webRoutes = [];
 
   /// Clears all registered routes from the server.
   /// Returns the [FinchApp] instance to allow method chaining.
@@ -116,7 +116,7 @@ class FinchApp {
   /// The [router] function returns a [Future] containing a list of [FinchRoute] based on the provided [Request].
   /// This allows for dynamic routing based on the request.
   /// Returns the [FinchApp] instance to allow method chaining.
-  FinchApp addRouting(Future<List<FinchRoute>> Function(Request rq) router) {
+  FinchApp addRouting(Future<List<FinchRoute>> Function() router) {
     _webRoutes.add(router);
 
     return this;
@@ -129,7 +129,7 @@ class FinchApp {
     List<FinchRoute> routing = [];
 
     for (var webRoute in _webRoutes) {
-      routing.addAll(await webRoute(Context.rq));
+      routing.addAll(await webRoute());
     }
 
     return routing;
@@ -981,7 +981,6 @@ class FinchApp {
             await debugger?.sendToAll({}, path: 'restartStarted');
             await stop(force: true);
             await start();
-            await getAllRoutes();
           }),
           'get_data': SocketEvent(onMessage: (socket, data) async {
             debugger?.sendToAll({
@@ -997,7 +996,6 @@ class FinchApp {
           'reinit': SocketEvent(onMessage: (socket, data) async {
             print("Server is restarting...");
             await restart();
-            await getAllRoutes();
           }),
         },
       );
@@ -1026,25 +1024,25 @@ class FinchApp {
           }, path: "updateMemory");
         },
       ).start();
-      _webRoutes.add((Request rq) async {
-        rq.buffer.writeln(
-            "<script src='${rq.url('/debugger/console.js')}'></script>");
+      _webRoutes.add(() async {
+        Context.rqOrNull?.buffer.writeln(
+            "<script src='${Context.rq.url('/debugger/console.js')}'></script>");
         return [
           FinchRoute(
             path: 'debugger',
             index: () async {
-              await debugger?.requestHandle(rq, userId: "LOCAL_USER");
+              await debugger?.requestHandle(Context.rq, userId: "LOCAL_USER");
               debugger?.sendToAll({
                 'type': 'user_connected',
                 'userId': "LOCAL_USER",
               });
-              return rq.renderSocket();
+              return Context.rq.renderSocket();
             },
             children: [
               FinchRoute(
                 path: 'console.js',
                 index: () async {
-                  return rq.renderString(
+                  return Context.rq.renderString(
                     text: ConsoleWidget().layout,
                     contentType: ContentType(
                       'text',
@@ -1077,11 +1075,11 @@ class FinchApp {
     Map<String, dynamic> params = const {},
     List<String> permissions = const [],
   }) {
-    _webRoutes.add((Request rq) async {
+    _webRoutes.add(() async {
       return [
         FinchRoute(
           path: path,
-          index: index != null ? () => index(rq) : null,
+          index: index != null ? () => index(Context.rq) : null,
           methods: methods,
           auth: auth,
           children: children,

--- a/lib/src/finch_app.dart
+++ b/lib/src/finch_app.dart
@@ -1377,5 +1377,5 @@ class _Info {
   /// - MINOR: New features (backward compatible)
   /// - PATCH: Bug fixes (backward compatible)
   /// - PRERELEASE: Pre-release identifiers (alpha, beta, rc)
-  final String version = '1.5.2-dev.1';
+  final String version = '1.5.2';
 }

--- a/lib/src/finch_app.dart
+++ b/lib/src/finch_app.dart
@@ -771,6 +771,64 @@ class FinchApp {
               ),
             ],
           ),
+          CappController(
+            'route',
+            description: 'Inspect routes',
+            run: (c) async {
+              var routes = await exploreAllRoutes();
+              var showDetail = c.existsOption('detail');
+              var table = <List<String>>[
+                [
+                  '#',
+                  'Method',
+                  'Path',
+                  'Auth',
+                  'Key',
+                  if (showDetail) ...[
+                    'Controller',
+                    'Function',
+                    'Type',
+                    'Permissions',
+                    'Middlewares',
+                    'Ports'
+                  ],
+                ],
+              ];
+              for (var route in routes) {
+                table.add([
+                  route['#'].toString(),
+                  route['method'].toString(),
+                  route['fullPath'].toString(),
+                  route['hasAuth'] ? 'Yes' : 'No',
+                  route['key']?.toString() ?? '-',
+                  if (showDetail) ...[
+                    route['controller']?.toString() ?? '-',
+                    route['index']?.toString() ?? '-',
+                    route['type']?.toString() ?? '-',
+                    route['permissions']?.toString() ?? '-',
+                    route['middlewares']?.toString() ?? '-',
+                    route['ports']?.toString() ?? '-',
+                  ]
+                ]);
+              }
+
+              CappConsole.writeTable(table, color: CappColors.success);
+              return CappConsole.empty;
+            },
+            options: [
+              _helpOption,
+              CappOption(
+                name: 'list',
+                shortName: 'l',
+                description: 'List all routes',
+              ),
+              CappOption(
+                name: 'detail',
+                shortName: 'd',
+                description: 'Show more details of routes',
+              ),
+            ],
+          ),
           ...commands,
         ],
       );

--- a/lib/src/finch_app.dart
+++ b/lib/src/finch_app.dart
@@ -1319,5 +1319,5 @@ class _Info {
   /// - MINOR: New features (backward compatible)
   /// - PATCH: Bug fixes (backward compatible)
   /// - PRERELEASE: Pre-release identifiers (alpha, beta, rc)
-  final String version = '1.5.1';
+  final String version = '1.5.2-dev.1';
 }

--- a/lib/src/render/request.dart
+++ b/lib/src/render/request.dart
@@ -1464,7 +1464,7 @@ class Request {
         Map<String, Object?> params = const {},
         Map<String, Object?> query = const {},
       ]) {
-        var res = FinchRoute.getByKey(key)?.getUrl(params, query);
+        var res = FinchRoute.getByKey(key)?.getUrl(this, params, query);
         if (res == null) {
           throw Exception("The route key '$key' not found!");
         }

--- a/lib/src/router/finch_route.dart
+++ b/lib/src/router/finch_route.dart
@@ -189,7 +189,8 @@ class FinchRoute {
     return _fullPath = _initFullPath();
   }
 
-  String getUrl([
+  String getUrl(
+    Request rq, [
     Map<String, Object?> params = const {},
     Map<String, Object?> queries = const {},
   ]) {
@@ -199,7 +200,7 @@ class FinchRoute {
     });
     Map<String, String> q =
         queries.map((key, value) => MapEntry(key, value.toString()));
-    return Context.rq.url(path, params: q);
+    return rq.url(path, params: q);
   }
 
   Map<String, Object?> toDetails() {
@@ -240,8 +241,8 @@ class FinchRoute {
   /// // For a GET request: returns true
   /// // For a DELETE request: returns false
   /// ```
-  bool allowMethod() {
-    return (methods.contains(Context.rq.method));
+  bool allowMethod(String method) {
+    return (methods.contains(method));
   }
 
   /// Converts the route to a list of maps representing its details.

--- a/lib/src/router/route.dart
+++ b/lib/src/router/route.dart
@@ -196,7 +196,7 @@ class Route {
     }
 
     if (endpoint == path) {
-      if (!route.allowMethod()) {
+      if (!route.allowMethod(rq.method)) {
         return (found: false, urlParams: urlParams);
       }
 

--- a/lib/src/tools/convertor/serializable/value_converter/json_value.dart
+++ b/lib/src/tools/convertor/serializable/value_converter/json_value.dart
@@ -1,7 +1,8 @@
 import 'dart:convert';
 import 'package:finch/finch_tools.dart';
 import 'package:finch/src/render/request.dart';
-import 'package:mcp_models/mcp_models.dart';
+import 'package:mcp_models/mcp_models_v2026.dart' as v26;
+import 'package:mcp_models/mcp_models_v2025.dart' as v25;
 import 'package:mongo_dart/mongo_dart.dart';
 
 /// Provides utility methods for encoding and decoding JSON data.
@@ -37,7 +38,9 @@ class FinchJson {
       if (obj is Duration) {
         return obj.toString();
       }
-
+      if (obj is v26.MCP || obj is v25.MCP) {
+        return obj.toMap();
+      }
       if (obj is Map) {
         return encodeMaps(obj);
       }
@@ -46,9 +49,6 @@ class FinchJson {
       }
       if (obj is int) {
         return obj;
-      }
-      if (obj is MCP) {
-        return obj.toMap();
       }
       return obj.toString();
     });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,7 +53,7 @@ dependencies:
   http: ^1.6.0
   capp: ^2.1.0
   mysql_client_plus: ^0.1.3
-  sqlite3: ^3.5.0
+  sqlite3: ^3.5.1
   sqler: ^1.2.1
   html_unescape: ^2.0.0
   yaml: ^3.1.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: finch
 description: Finch is a fast, lightweight Dart framework for building scalable server-side web apps, REST APIs, databases, WebSockets, and MCP servers
 
-version: 1.5.2-dev.1
+version: 1.5.2
 homepage: https://finchdart.com/
 repository: https://github.com/uproid/finch.git
 issue_tracker: https://github.com/uproid/finch/issues
@@ -57,7 +57,7 @@ dependencies:
   sqler: ^1.2.1
   html_unescape: ^2.0.0
   yaml: ^3.1.3
-  mcp_models: 2.0.0
+  mcp_models: 2.1.0
 executables:
   finch: finch
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: finch
 description: Finch is a fast, lightweight Dart framework for building scalable server-side web apps, REST APIs, databases, WebSockets, and MCP servers
 
-version: 1.5.1
+version: 1.5.2-dev.1
 homepage: https://finchdart.com/
 repository: https://github.com/uproid/finch.git
 issue_tracker: https://github.com/uproid/finch/issues

--- a/test/finch_debugging_test.dart
+++ b/test/finch_debugging_test.dart
@@ -21,16 +21,16 @@ void main() async {
     ),
   );
 
-  Future<List<FinchRoute>> routing(Request rq) async {
+  Future<List<FinchRoute>> routing() async {
     return [
       FinchRoute(
         path: "/",
-        index: () => rq.renderString(text: "TEST"),
+        index: () => Context.rq.renderString(text: "TEST"),
         children: [
           FinchRoute(
             path: 'checkurl',
             index: () {
-              return rq.renderView(
+              return Context.rq.renderView(
                 path: "{{ \$e.url('test') }}",
                 isFile: false,
               );
@@ -46,14 +46,15 @@ void main() async {
             path: 'debug_test',
             methods: Methods.ALL,
             index: () {
-              return rq.renderView(path: "<h1>Debug Test</h1>", isFile: false);
+              return Context.rq
+                  .renderView(path: "<h1>Debug Test</h1>", isFile: false);
             },
           ),
           FinchRoute(
             path: 'widget',
             index: () {
-              rq.addParam("testParam", "paramValue");
-              return rq.renderView(
+              Context.rq.addParam("testParam", "paramValue");
+              return Context.rq.renderView(
                 path: "{{ \$e.url('test') }}\n"
                     "{{ testParam }}\n"
                     "{{ \$t('test.translate') }}\n",
@@ -65,19 +66,19 @@ void main() async {
             path: "api/info",
             methods: Methods.ONLY_GET,
             index: () {
-              rq.addParam("data", "TEST");
-              return rq.renderData(data: rq.getParams());
+              Context.rq.addParam("data", "TEST");
+              return Context.rq.renderData(data: Context.rq.getParams());
             },
           ),
           FinchRoute(
             path: "api/post",
             methods: Methods.ONLY_POST,
             index: () {
-              return rq.renderData(data: {
-                'sended': rq.getAll(),
+              return Context.rq.renderData(data: {
+                'sended': Context.rq.getAll(),
                 'cookies': {
-                  'sessionId': rq.getCookie('sessionId', safe: false),
-                  'username': rq.getCookie('username', safe: false),
+                  'sessionId': Context.rq.getCookie('sessionId', safe: false),
+                  'username': Context.rq.getCookie('username', safe: false),
                 },
               });
             },

--- a/test/finch_server_test.dart
+++ b/test/finch_server_test.dart
@@ -26,25 +26,25 @@ void main() async {
     ),
   );
 
-  Future<List<FinchRoute>> routing(Request rq) async {
+  Future<List<FinchRoute>> routing() async {
     return [
       FinchRoute(
         path: "/",
-        index: () => rq.renderString(text: "TEST"),
+        index: () => Context.rq.renderString(text: "TEST"),
         children: [
           FinchRoute(
             path: '/without_cache_test',
             index: () async {
-              rq.assetManager.includes = [];
-              rq.addAsset(Asset(
+              Context.rq.assetManager.includes = [];
+              Context.rq.addAsset(Asset(
                   path: 'public/test.css',
                   type: AssetType.css,
                   cache: AssetCache.appVersion));
-              rq.addAsset(Asset(
+              Context.rq.addAsset(Asset(
                   path: 'public/test.js',
                   type: AssetType.js,
                   cache: AssetCache.appVersion));
-              return rq.renderView(
+              return Context.rq.renderView(
                 path:
                     '{{ assets.css() }}, {{ assets.js() }}, {{ assets.dataJs() }}',
                 isFile: false,
@@ -54,16 +54,16 @@ void main() async {
           FinchRoute(
             path: '/with_cache_test',
             index: () async {
-              rq.assetManager.includes = [];
-              rq.addAsset(Asset(
+              Context.rq.assetManager.includes = [];
+              Context.rq.addAsset(Asset(
                   path: 'public/test.css',
                   type: AssetType.css,
                   cache: AssetCache.appVersion));
-              rq.addAsset(Asset(
+              Context.rq.addAsset(Asset(
                   path: 'public/test.js',
                   type: AssetType.js,
                   cache: AssetCache.appVersion));
-              return rq.renderView(
+              return Context.rq.renderView(
                 path:
                     '{{ assets.css() }}, {{ assets.js() }}, {{ assets.dataJs() }}',
                 isFile: false,
@@ -73,22 +73,22 @@ void main() async {
           FinchRoute(
             path: '/test_cookies/list',
             index: () {
-              rq.addCookie('SYSTEM_TEST', 'TEST_VALUE_2', safe: false);
-              return rq.renderDataParam(data: {
-                'cookies': rq.cookies,
-                'cookies_res': rq.response.cookies,
+              Context.rq.addCookie('SYSTEM_TEST', 'TEST_VALUE_2', safe: false);
+              return Context.rq.renderDataParam(data: {
+                'cookies': Context.rq.cookies,
+                'cookies_res': Context.rq.response.cookies,
               });
             },
           ),
           FinchRoute(
             path: '/test_cookies/delete_cookies',
             index: () {
-              var key = rq.get<String>('key');
+              var key = Context.rq.get<String>('key');
               Console.i("Deleting cookie with key: $key");
-              rq.removeCookie(key);
-              return rq.renderDataParam(data: {
-                'cookies': rq.cookies,
-                'cookies_res': rq.response.cookies,
+              Context.rq.removeCookie(key);
+              return Context.rq.renderDataParam(data: {
+                'cookies': Context.rq.cookies,
+                'cookies_res': Context.rq.response.cookies,
                 'key_to_delete': key,
               });
             },
@@ -98,7 +98,7 @@ void main() async {
             methods: Methods.GET_ONLY,
             index: () async {
               var _ = TestAdvancedForm();
-              return rq.renderDataParam();
+              return Context.rq.renderDataParam();
             },
           ),
           FinchRoute(
@@ -119,11 +119,11 @@ void main() async {
             index: () async {
               late String ln;
               for (var i = 0; i < 10; i++) {
-                ln = rq.getLanguage();
+                ln = Context.rq.getLanguage();
               }
-              return rq.renderDataParam(data: {
-                'cookies': rq.cookies,
-                'cookies_res': rq.response.cookies,
+              return Context.rq.renderDataParam(data: {
+                'cookies': Context.rq.cookies,
+                'cookies_res': Context.rq.response.cookies,
                 'language': ln,
               });
             },
@@ -134,7 +134,7 @@ void main() async {
             index: () async {
               var form = TestAdvancedForm();
               await form.check();
-              return rq.renderDataParam();
+              return Context.rq.renderDataParam();
             },
           ),
           FinchRoute(
@@ -150,17 +150,17 @@ void main() async {
                   );
                 },
               ).take(10);
-              return rq.renderSSE(stream);
+              return Context.rq.renderSSE(stream);
             },
           ),
           FinchRoute(
             path: 'htmler',
             index: () {
-              rq.addParam('variable', 'VALUE');
-              rq.addParam('list', ['item1', 'item2', 'item3', 'item4']);
-              rq.addParam('condition', true);
+              Context.rq.addParam('variable', 'VALUE');
+              Context.rq.addParam('list', ['item1', 'item2', 'item3', 'item4']);
+              Context.rq.addParam('condition', true);
 
-              return rq.renderTag(
+              return Context.rq.renderTag(
                   pretty: true,
                   tag: $Html(
                     attrs: {
@@ -229,7 +229,7 @@ void main() async {
           FinchRoute(
             path: 'checkurl',
             index: () {
-              return rq.renderView(
+              return Context.rq.renderView(
                 path: "{{ \$e.url('test') }}",
                 isFile: false,
               );
@@ -245,14 +245,15 @@ void main() async {
             path: 'debug_test',
             methods: Methods.ALL,
             index: () {
-              return rq.renderView(path: "<h1>Debug Test</h1>", isFile: false);
+              return Context.rq
+                  .renderView(path: "<h1>Debug Test</h1>", isFile: false);
             },
           ),
           FinchRoute(
             path: 'widget',
             index: () {
-              rq.addParam("testParam", "paramValue");
-              return rq.renderView(
+              Context.rq.addParam("testParam", "paramValue");
+              return Context.rq.renderView(
                 path: "{{ \$e.url('test') }}\n"
                     "{{ testParam }}\n"
                     "{{ \$t('test.translate') }}\n",
@@ -264,17 +265,17 @@ void main() async {
             path: "api/info",
             methods: Methods.ONLY_GET,
             index: () {
-              rq.addParam("data", "TEST");
-              return rq.renderData(data: rq.getParams());
+              Context.rq.addParam("data", "TEST");
+              return Context.rq.renderData(data: Context.rq.getParams());
             },
           ),
           FinchRoute(
             path: "api",
             index: () {
-              return rq.renderView(
+              return Context.rq.renderView(
                 path: '',
-                data: {'is_api': rq.isApiEndpoint},
-                toData: rq.isApiEndpoint,
+                data: {'is_api': Context.rq.isApiEndpoint},
+                toData: Context.rq.isApiEndpoint,
               );
             },
           ),
@@ -282,11 +283,11 @@ void main() async {
             path: "api/post",
             methods: Methods.ONLY_POST,
             index: () {
-              return rq.renderData(data: {
-                'sended': rq.getAll(),
+              return Context.rq.renderData(data: {
+                'sended': Context.rq.getAll(),
                 'cookies': {
-                  'sessionId': rq.getCookie('sessionId', safe: false),
-                  'username': rq.getCookie('username', safe: false),
+                  'sessionId': Context.rq.getCookie('sessionId', safe: false),
+                  'username': Context.rq.getCookie('username', safe: false),
                 },
               });
             },
@@ -296,7 +297,7 @@ void main() async {
             methods: Methods.ALL,
             auth: AppAuthController(true),
             index: () {
-              return rq.renderData(data: {
+              return Context.rq.renderData(data: {
                 'user': "TEST",
               });
             },
@@ -306,7 +307,7 @@ void main() async {
             methods: Methods.ALL,
             auth: AppAuthController(false),
             index: () {
-              return rq.renderData(data: {
+              return Context.rq.renderData(data: {
                 'user': "TEST",
               });
             },
@@ -314,25 +315,25 @@ void main() async {
           FinchRoute(
             path: '/check_param_classic/:key1/:key2',
             index: () async {
-              return rq.renderData(data: {
-                'key1': rq.getParam('key1'),
-                'key2': rq.getParam('key2'),
+              return Context.rq.renderData(data: {
+                'key1': Context.rq.getParam('key1'),
+                'key2': Context.rq.getParam('key2'),
               });
             },
           ),
           FinchRoute(
             path: '/check_param_finch/:key1/:key2',
             index: () async {
-              return rq.renderData(data: {
-                'key1': rq.getParam('key1'),
-                'key2': rq.getParam('key2'),
+              return Context.rq.renderData(data: {
+                'key1': Context.rq.getParam('key1'),
+                'key2': Context.rq.getParam('key2'),
               });
             },
           ),
           FinchRoute(
             path: '/%AF/test',
             index: () async {
-              return rq.renderData(data: {
+              return Context.rq.renderData(data: {
                 'key1': 'value1',
                 'key2': 'value2',
               });


### PR DESCRIPTION
## 1.5.2
- Removed the `Request rq` parameter from `FinchApp.addRouting()` callbacks; request data remains available through `Context.rq` inside route handlers
- Improved route URL generation and method checks by passing request-specific values explicitly
- Fix issue [#80](https://github.com/uproid/finch/issues/80): Support the Previous MCP Protocol Version with an Extended Deprecation Period

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple MCP protocol versions, including version-specific tools, resources, prompts, and responses.
  * Added a route-listing CLI command with optional detailed route information.
  * Added safe access to the current request when no request context is available.
* **Improvements**
  * Improved route URL generation and HTTP method validation.
  * Simplified routing callbacks by accessing requests through the current context.
  * Improved debugger restart and server lifecycle behavior.
* **Chores**
  * Updated the framework to version 1.5.2 and extended support for the previous MCP protocol version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->